### PR TITLE
Adjust target volumes for Ki67Advanced phenotype

### DIFF
--- a/PhenoCellPy/phases.py
+++ b/PhenoCellPy/phases.py
@@ -824,9 +824,7 @@ class Ki67PositivePreMitotic(Ki67Positive):
                  cytoplasm_fluid=None, cytoplasm_solid=None, cytoplasm_solid_target=None,
                  target_cytoplasm_to_nuclear_ratio=None, calcified_fraction=None, fluid_change_rate=None,
                  relative_rupture_volume=None, user_phase_time_step=None, user_phase_time_step_args=None):
-        if entry_function is None:
-            # otherwise it will be defaulted to the halving target volume function by Ki67Positive
-            entry_function = False
+
 
         super().__init__(index=index, previous_phase_index=previous_phase_index, next_phase_index=next_phase_index,
                          dt=dt, time_unit=time_unit, space_unit=space_unit,

--- a/PhenoCellPy/phenotypes.py
+++ b/PhenoCellPy/phenotypes.py
@@ -794,7 +794,7 @@ class Ki67Advanced(Phenotype):
                  division_at_phase_exits=(False, True, False), removal_at_phase_exits=(False, False, False),
                  fixed_durations=(False, True, True), phase_durations: list = (3.62 * 60, 13.0 * 60.0, 2.5 * 60),
                  entry_functions=(None, None, None), entry_functions_args=(None, None, None),
-                 exit_functions=(None, None, None), exit_functions_args=(None, None, None),
+                 exit_functions=(None, False, None), exit_functions_args=(None, None, None),
                  arrest_functions=(None, None, None), arrest_functions_args=(None, None, None),
                  check_transition_to_next_phase_functions=(None, None, None),
                  check_transition_to_next_phase_functions_args: list = (None, None, None), simulated_cell_volume=None,


### PR DESCRIPTION
Changes to get Ki67Advanced phenotype to work appropriately. Both changes deal with making sure target volumes are set correctly.